### PR TITLE
Fix optional return type in example

### DIFF
--- a/python/examples/basic_usage.py
+++ b/python/examples/basic_usage.py
@@ -6,6 +6,7 @@ Demonstrates core functionality including user info, countries, and proxy usage.
 
 import os
 import sys
+from typing import Optional
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -20,7 +21,7 @@ except ImportError as e:
     sys.exit(1)
 
 
-def test_proxy_connection(description: str, proxy_config: dict) -> str:
+def test_proxy_connection(description: str, proxy_config: dict) -> Optional[str]:
     """Test proxy connection and return IP address."""
     try:
         # Use our IP checking function


### PR DESCRIPTION
## Summary
- update `test_proxy_connection` return type to `Optional[str]`
- import `Optional` from typing

## Testing
- `python -m py_compile python/examples/basic_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9d0a1090832b9feb915b920ad575