### PR TITLE
Add tests for utils

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -170,6 +170,16 @@ proxy_url = get_socks5_proxy(country="us", filter="medium")
 proxy_url = get_socks5_proxy(country="us", filter="low")
 ```
 
+## 🧪 Running Tests
+
+The project uses `pytest` for unit tests. Install the development
+dependencies and run the test suite from the repository root:
+
+```bash
+pip install -e ./python[dev]
+pytest
+```
+
 ## 🔗 Links
 
 - [🌐 NodeMaven Dashboard](https://dashboard.nodemaven.com?utm_source=github&utm_medium=github_post&utm_campaign=developer_outreach&utm_content=python_dashboard)

--- a/python/quick_test.py
+++ b/python/quick_test.py
@@ -4,6 +4,9 @@ Quick test script for NodeMaven proxy functionality.
 Tests API connection, proxy credentials, and basic proxy functionality.
 """
 
+# Prevent pytest from treating this script as a test module
+__test__ = False
+
 import os
 import sys
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+# Add the python package directory to import nodemaven
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+from nodemaven.utils import build_proxy_username
+
+
+def test_country_option():
+    result = build_proxy_username('testuser', country='US')
+    assert result == 'testuser-country-us-ipv4-true-filter-medium'
+
+
+def test_city_option():
+    result = build_proxy_username('testuser', country='US', city='New York')
+    assert result == 'testuser-country-us-city-newyork-ipv4-true-filter-medium'
+
+
+def test_session_option():
+    result = build_proxy_username('testuser', session='abc123')
+    assert result == 'testuser-ipv4-true-sid-abc123-filter-medium'
+


### PR DESCRIPTION
## Summary
- add pytest-based tests for `build_proxy_username`
- document running the test suite in the Python README
- prevent pytest from loading `quick_test.py` as a test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9d15459c832b9008ae51a93931ca