### PR TITLE
Add unit tests for Python SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,14 +143,15 @@ last_ip_check.json
 ip_results.json
 
 # Test and debug files (but keep main quick_test.py)
-test_*.py
-debug_*.py
-simple_*.py
-working_*.py
-temp_*.py
-experimental_*.py
-# Exclude test files but keep the main quick_test.py
-*_test.py
+# The SDK now includes unit tests
+#!test_*.py
+#!debug_*.py
+#!simple_*.py
+#!working_*.py
+#!temp_*.py
+#!experimental_*.py
+# *_test.py files are now tracked
+#!*_test.py
 !quick_test.py
 
 # Development artifacts

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from unittest import mock
+
+# ensure package path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+from nodemaven.client import NodeMavenClient
+
+
+def test_client_initialization_env(monkeypatch):
+    monkeypatch.setenv('NODEMAVEN_APIKEY', 'testkey')
+    client = NodeMavenClient()
+    assert client.api_key == 'testkey'
+    assert client.base_url.endswith('dashboard.nodemaven.com')
+
+
+def test_client_custom_params():
+    client = NodeMavenClient(api_key='a', base_url='https://example.com', timeout=5)
+    assert client.api_key == 'a'
+    assert client.base_url == 'https://example.com'
+    assert client.timeout == 5

--- a/tests/test_ip_checker.py
+++ b/tests/test_ip_checker.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+# ensure package path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+from ip_checker import SimpleIPChecker
+
+
+def test_format_results_error():
+    checker = SimpleIPChecker()
+    result = {'error': 'fail'}
+    formatted = checker.format_results(result)
+    assert 'Error' in formatted
+
+
+def test_format_results_success():
+    checker = SimpleIPChecker()
+    data = {
+        'ip': '1.1.1.1',
+        'timestamp': 'now',
+        'country': 'US',
+        'city': 'NY',
+        'region': 'NY',
+        'isp': 'ISP',
+        'org': 'Org',
+        'as': 'AS',
+    }
+    formatted = checker.format_results(data)
+    assert 'IP Address' in formatted
+    assert 'ISP' in formatted

--- a/tests/test_quick_test.py
+++ b/tests/test_quick_test.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import quick_test
+
+
+def test_test_proxy_connection_success():
+    with mock.patch('quick_test.get_current_ip', return_value='1.2.3.4'):
+        result = quick_test.test_proxy_connection('desc', {'http': 'url'})
+        assert result is True
+
+
+def test_test_proxy_connection_failure():
+    with mock.patch('quick_test.get_current_ip', return_value=None):
+        result = quick_test.test_proxy_connection('desc', {'http': 'url'})
+        assert result is False


### PR DESCRIPTION
## Summary
- start tracking Python tests by adjusting `.gitignore`
- add unit tests for `NodeMavenClient`
- cover `SimpleIPChecker` formatting logic
- test quick test helper

## Testing
- `python3 -m pip install -e ./python[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9f6e5020832b8705e13cdd76b288